### PR TITLE
fix login API / add register API and refresh_token

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,9 +1,101 @@
-from fastapi import APIRouter, Depends
+import jwt
+import pymysql
+
+from fastapi import APIRouter
+from datetime import datetime, timedelta
+from starlette.responses import JSONResponse
+
+from app.models import AuthType
 
 
 router = APIRouter()
+SECRET_KEY = 'secret_key'  # 임시
 
 
-@router.get("/login")
-async def login():
-    pass
+@router.get("/login", status_code=200)
+async def login(auth_type: AuthType, username: str = None, password: str = None, token_id: str = None):
+
+    if (username is None) or (password is None):  # 둘 중 하나라도 입력되지 않으면 400 반환
+        return JSONResponse(status_code=400, content=dict(msg="ID or PW Not Provided"))
+
+    try:
+        conn = pymysql.connect(host='localhost', user='root', password='1234!', db='funcktionsql', charset='utf8')  # 임시
+        cur = conn.cursor(pymysql.cursors.DictCursor)
+
+        cur.execute('SELECT id, username, password FROM Users WHERE username = %s', username)
+        info = cur.fetchone()
+
+        if info is None: #계정 존재여부 확인
+            return JSONResponse(status_code=400, content=dict(msg="NO MATCH USER"))
+        else:
+            if info['password'] != password:  # 비밀번호 일치여부 확인
+                return JSONResponse(status_code=400, content=dict(msg="NO MATCH USER"))
+            if auth_type != AuthType.NON_SOCIAL:  # 소셜 로그인인 경우 auth_key 확인
+                cur.execute('SELECT auth_key FROM Auth WHERE user_id = %s', int(info['id']))
+                if token_id != cur.fetchone()['auth_key']:
+                    return JSONResponse(status_code=400, content=dict(msg="NO MATCH USER3"))
+
+    finally:
+        cur.close()
+        conn.close()
+
+    token = create_access_token(username, int(info['id']))
+    create_refresh_token(username, int(info['id']))
+    return JSONResponse(status_code=200, content=token)  # token 반환
+
+
+
+@router.get("/register", status_code=200)
+async def register(username, password, auth_type: AuthType, token_id: str = None):
+    try:
+        conn = pymysql.connect(host='localhost', user='root', password='1234', db='funcktionsql', charset='utf8')  # 임시
+        cur = conn.cursor(pymysql.cursors.DictCursor)
+
+        cur.execute('SELECT * FROM Users WHERE username=%s', username)
+        exist = cur.fetchone()
+        if exist is not None:
+            return JSONResponse(status_code=400, content=dict(msg = "Unavailable ID"))
+
+        cur.execute('INSERT INTO Users (username, password) VALUES (%s,%s)', (username, password))
+        conn.commit()
+        cur.execute('SELECT id FROM Users WHERE username=%s', username)
+        user_id = cur.fetchone()['id']
+        cur.execute('INSERT INTO Auth (user_id, type, auth_key) VALUES (%s, %s, %s)', (user_id, int(auth_type), token_id))
+        conn.commit()
+
+    finally:
+        cur.close()
+        conn.close()
+
+    return JSONResponse(status_code=200, content=dict(msg = "Success"))
+
+
+
+def create_access_token(username, user_id):
+    payload = {
+        'user_id' : user_id,
+        'username' : username,
+        'exp' : datetime.utcnow() + timedelta(hours=2)
+    }
+    access_token = jwt.encode(payload, SECRET_KEY, algorithm='HS256')
+    return access_token
+
+
+
+def create_refresh_token(username, user_id):
+    payload = {
+        'user_id' : user_id,
+        'username': username,
+        'exp': datetime.utcnow() + timedelta(hours=24*7)
+    }
+    refresh_token = jwt.encode(payload, SECRET_KEY, algorithm='HS256')
+
+    try:
+        conn = pymysql.connect(host='localhost', user='root', password='1234', db='funcktionsql', charset='utf8')  # 임시
+        cur = conn.cursor(pymysql.cursors.DictCursor)
+
+        cur.execute('UPDATE Auth SET refresh_token = %s WHERE user_id = %s', (refresh_token, user_id))
+        conn.commit()
+    finally:
+        cur.close()
+        conn.close()


### PR DESCRIPTION
원래 DB에 없는 소셜로그인 이용자의 경우 DB에 저장하고 바로 토큰을 발행해주는 방향으로 되어있었는데
token body에 user_id를 추가하면서 위 같은 경우에 DB에 저장 후 다시 user_id를 받아오는 과정에서 불편함이 생겨 여러 방법을 시도해보다가 결국 소셜로그인의 최초 DB 저장도 register를 통해서만 할 수 있게 우선은 고치게 되었습니다 ...!

우선은 이때까지 한 코드 pr해두겠습니다 ..!